### PR TITLE
Add Blender version panel addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # sample16
-blender plugin
+
+A simple Blender add-on that shows the current Blender version in the N panel.
+
+## Installation
+
+1. Open Blender and go to **Edit > Preferences > Add-ons**.
+2. Click **Install** and select `blender_version_panel.py` from this repository.
+3. Enable the add-on from the list.
+4. Open the 3D Viewport and press **N** to open the Sidebar. A new tab named **Version** will display the current Blender version.
+

--- a/blender_version_panel.py
+++ b/blender_version_panel.py
@@ -1,0 +1,33 @@
+bl_info = {
+    "name": "Blender Version Panel",
+    "author": "OpenAI Codex",
+    "version": (1, 0, 0),
+    "blender": (2, 80, 0),
+    "location": "View3D > Sidebar",
+    "description": "Display the current Blender version in the N panel",
+    "category": "3D View"
+}
+
+import bpy
+
+class VIEW3D_PT_blender_version(bpy.types.Panel):
+    bl_label = "Blender Version"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = "Version"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.label(text=f"Blender version: {bpy.app.version_string}")
+
+
+def register():
+    bpy.utils.register_class(VIEW3D_PT_blender_version)
+
+
+def unregister():
+    bpy.utils.unregister_class(VIEW3D_PT_blender_version)
+
+
+if __name__ == "__main__":
+    register()


### PR DESCRIPTION
## Summary
- add Blender addon `blender_version_panel.py` that shows the current version in the Sidebar
- document usage in README

## Testing
- `python -m py_compile blender_version_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_6857f7c79944832eb2c36784944603ad