### PR TITLE
Fix Windows packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ A simple Blender add-on that shows the current Blender version in the N panel.
 3. Enable the add-on from the list.
 4. Open the 3D Viewport and press **N** to open the Sidebar. A new tab named **Version** will display the current Blender version.
 
+
+## Packaging on Windows
+
+If you need a ZIP file for installation, run `package_addon.bat` from this
+directory. The script creates `blender_version_panel.zip` containing a folder
+named `blender_version_panel` with `__init__.py` inside. Install the ZIP via
+Blender's add-on preferences.

--- a/package_addon.bat
+++ b/package_addon.bat
@@ -1,0 +1,19 @@
+@echo off
+setlocal
+set ADDON_NAME=blender_version_panel
+set PACKAGE_FILE=%ADDON_NAME%.zip
+
+echo Preparing add-on package...
+
+if exist %PACKAGE_FILE% del /Q %PACKAGE_FILE%
+if exist %ADDON_NAME% rmdir /S /Q %ADDON_NAME%
+mkdir %ADDON_NAME%
+
+copy /Y blender_version_panel.py %ADDON_NAME%\__init__.py >nul
+
+powershell -NoLogo -NoProfile -Command "Compress-Archive -Path %ADDON_NAME% -DestinationPath %PACKAGE_FILE% -Force"
+
+rmdir /S /Q %ADDON_NAME%
+
+echo Package created: %PACKAGE_FILE%
+endlocal


### PR DESCRIPTION
## Summary
- ensure `__init__.py` is packaged correctly in `blender_version_panel.zip`
- document the updated ZIP structure in the README

## Testing
- `python -m py_compile blender_version_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_6857f844e210832e95db3e998e7ab520