### PR TITLE
Update Blender addon panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # sample16
 
-A simple Blender add-on that shows the current Blender version in the N panel.
+A simple Blender add-on that exposes the scene's frame range in a sidebar tab.
 
 ## Installation
 
 1. Open Blender and go to **Edit > Preferences > Add-ons**.
 2. Click **Install** and select `blender_version_panel.py` from this repository.
 3. Enable the add-on from the list.
-4. Open the 3D Viewport and press **N** to open the Sidebar. A new tab named **Version** will display the current Blender version.
+4. Open the 3D Viewport and press **N** to open the Sidebar. A tab named **テストプラグイン** shows inputs for **Frame Start** and **Frame End**.
+
 

--- a/blender_version_panel.py
+++ b/blender_version_panel.py
@@ -1,32 +1,33 @@
 bl_info = {
-    "name": "Blender Version Panel",
+    "name": "Test Plugin Panel",
     "author": "OpenAI Codex",
     "version": (1, 0, 0),
     "blender": (2, 80, 0),
     "location": "View3D > Sidebar",
-    "description": "Display the current Blender version in the N panel",
+    "description": "Show frame range controls in the N panel",
     "category": "3D View"
 }
 
 import bpy
 
-class VIEW3D_PT_blender_version(bpy.types.Panel):
-    bl_label = "Blender Version"
+class VIEW3D_PT_test_plugin(bpy.types.Panel):
+    bl_label = "テストプラグイン"
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_category = "Version"
+    bl_category = "テストプラグイン"
 
     def draw(self, context):
         layout = self.layout
-        layout.label(text=f"Blender version: {bpy.app.version_string}")
+        layout.prop(context.scene, "frame_start")
+        layout.prop(context.scene, "frame_end")
 
 
 def register():
-    bpy.utils.register_class(VIEW3D_PT_blender_version)
+    bpy.utils.register_class(VIEW3D_PT_test_plugin)
 
 
 def unregister():
-    bpy.utils.unregister_class(VIEW3D_PT_blender_version)
+    bpy.utils.unregister_class(VIEW3D_PT_test_plugin)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rename panel to テストプラグイン
- remove Blender version display
- show Frame Start and Frame End fields
- remove packaging script

## Testing
- `python -m py_compile blender_version_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_6857f844e210832e95db3e998e7ab520