### PR TITLE
Update plugin labels

### DIFF
--- a/blender_version_panel.py
+++ b/blender_version_panel.py
@@ -19,8 +19,11 @@ class VIEW3D_PT_test_plugin(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         row = layout.row(align=True)
-        row.prop(context.scene, "frame_start")
-        row.prop(context.scene, "frame_end")
+        # Display the frame range with localized labels so that the start
+        # frame appears on the left as "開始" and the end frame on the right
+        # as "終了".
+        row.prop(context.scene, "frame_start", text="開始")
+        row.prop(context.scene, "frame_end", text="終了")
 
 def register():
     bpy.utils.register_class(VIEW3D_PT_test_plugin)


### PR DESCRIPTION
## Summary
- show Japanese start/end labels in Blender panel

## Testing
- `python3 -m py_compile blender_version_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_685801e33f4c832e8cf5959e1a7f4d62